### PR TITLE
Project compilation fix

### DIFF
--- a/app-core/pom.xml
+++ b/app-core/pom.xml
@@ -87,6 +87,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/app-local-updater/pom.xml
+++ b/app-local-updater/pom.xml
@@ -43,6 +43,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/app-shared/pom.xml
+++ b/app-shared/pom.xml
@@ -9,13 +9,13 @@
     <version>1.0.0.5</version>
     <packaging>jar</packaging>
     <dependencies>
-
     </dependencies>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/app-ui/pom.xml
+++ b/app-ui/pom.xml
@@ -70,6 +70,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -83,6 +83,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>


### PR DESCRIPTION
I wasn't able to build the project, because lombok didn't generate code properly. This was caused by the outdated version of the maven-compiler-plugin (since the version wasn't specified manually i think it just picked latest found version at my repo cache)
The fix is simple - i manually specified version (i used one of the latest releases)