### PR TITLE
Update PoeMap regexp

### DIFF
--- a/app-core/src/main/java/com/mercury/platform/shared/MessageParser.java
+++ b/app-core/src/main/java/com/mercury/platform/shared/MessageParser.java
@@ -17,7 +17,7 @@ public class MessageParser {
     private final static String poeAppPattern = "^(.*\\s)?(.+): (\\s*?wtb\\s+?(.+?)(\\s+?listed for\\s+?([\\d\\.]+?)\\s+?(.+))?\\s+?in\\s+?(.+?)\\s+?\\(stash\\s+?\"(.*?)\";\\s+?left\\s+?(\\d+?),\\s+?top\\s+(\\d+?)\\)\\s*?(.*))$";
     private final static String poeAppBulkCurrenciesPattern = "^(.*\\s)?(.+): (\\s*?wtb\\s+?(.+?)(\\s+?listed for\\s+?([\\d\\.]+?)\\s+?(.+))?\\s+?in\\s+?(.+?)\\s+?\\(stash\\s+?\"(.*?)\";\\s+?left\\s+?(\\d+?),\\s+?top\\s+(\\d+?)\\)\\s*?(.*))$";
     private final static String poeCurrencyPattern = "^(.*\\s)?(.+): (.+ to buy your (\\d+(\\.\\d+)?)? (.+) for my (\\d+(\\.\\d+)?)? (.+) in (.*?)\\.\\s*(.*))$";
-    private final static String poeMapLiveRegex = "^(.*\\s)?(.+): (I'd like to exchange my (T\\d+:\\s\\([\\s\\S,]+) for your (T\\d+:\\s\\([\\S,\\s]+) in\\s+?(.+?)\\.)";
+    private final static String poeMapLiveRegex = "^(.*\\s)?(.+): (I'd like to exchange my (.+:\\s\\([\\s\\S,]+) for your (.+:\\s\\([\\S,\\s]+) in\\s+?(.+?)\\.)";
     private Pattern poeAppItemPattern;
     private Pattern poeTradeStashItemPattern;
     private Pattern poeTradeItemPattern;


### PR DESCRIPTION
New map tiers were introduced for unique maps and fragments: U and F. It can be extended at any time. It is not enough to capture tiers using T\\\d+.
Message example:
```@From <Guild> User: I'd like to exchange my U: (Mao Kun), F: (Fragment of the Phoenix), T9: (Castle Ruins) for your U: (Poorjoy's Asylum), F: (Fragment of the Hydra), T9: (Lighthouse) in Hardcore Legion.```

